### PR TITLE
PHP iterator signature update

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -63,10 +63,10 @@ class Query implements \Iterator
         return false;
     }
 
-    public function next()
+    public function next(): void
     {
         if ($this->more()) {
-            return $this->cache[$this->pos++];
+            $this->pos++;
         }
     }
 
@@ -95,22 +95,22 @@ class Query implements \Iterator
         return $s;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->cache[$this->pos];
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->pos;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->more();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -12,10 +12,10 @@ namespace Caxy\BaseX;
 
 class Query implements \Iterator
 {
-    protected $session;
-    protected $id;
-    protected $cache;
-    protected $pos;
+    protected Session $session;
+    protected string $id;
+    protected ?array $cache = null;
+    protected int $pos = 0;
 
     /**
      * Query constructor.
@@ -23,28 +23,28 @@ class Query implements \Iterator
      * @param Session $session
      * @param string $query
      */
-    public function __construct($session, $query)
+    public function __construct(Session $session, string $query)
     {
         $this->session = $session;
         $this->id = $this->exec(chr(0), $query);
     }
 
-    public function bind($name, $value, $type = "")
+    public function bind(string $name, string $value, string $type = ""): void
     {
         $this->exec(chr(3), $this->id.chr(0).$name.chr(0).$value.chr(0).$type);
     }
 
-    public function context($value, $type = "")
+    public function context(string $value, string $type = ""): void
     {
         $this->exec(chr(14), $this->id.chr(0).$value.chr(0).$type);
     }
 
-    public function execute()
+    public function execute(): string
     {
         return $this->exec(chr(5), $this->id);
     }
 
-    public function more()
+    public function more(): bool
     {
         if ($this->cache === null) {
             $this->pos = 0;
@@ -70,22 +70,22 @@ class Query implements \Iterator
         }
     }
 
-    public function info()
+    public function info(): string
     {
         return $this->exec(chr(6), $this->id);
     }
 
-    public function options()
+    public function options(): string
     {
         return $this->exec(chr(7), $this->id);
     }
 
-    public function close()
+    public function close(): void
     {
         $this->exec(chr(2), $this->id);
     }
 
-    public function exec($cmd, $arg)
+    public function exec(string $cmd, string $arg): string
     {
         $this->session->send($cmd.$arg);
         $s = $this->session->receive();

--- a/src/Session.php
+++ b/src/Session.php
@@ -13,13 +13,13 @@ namespace Caxy\BaseX;
 class Session
 {
     // instance variables.
-    protected $socket;
-    protected $info;
-    protected $buffer;
-    protected $bpos;
-    protected $bsize;
+    protected \Socket|false $socket;
+    protected ?string $info = null;
+    protected string $buffer = '';
+    protected int $bpos = 0;
+    protected int $bsize = 0;
 
-    public function __construct($hostname, $port, $user, $password)
+    public function __construct(string $hostname, int $port, string $user, string $password)
     {
         // create server connection
         $this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
@@ -54,7 +54,7 @@ class Session
      * @param string $command
      * @return string
      */
-    public function execute($command)
+    public function execute(string $command): string
     {
         // send command to server
         socket_write($this->socket, $command.chr(0));
@@ -63,7 +63,7 @@ class Session
         $result = $this->receive();
         $this->info = $this->readString();
         if ($this->ok() != true) {
-            throw new BaseXException($this->info);
+            throw new BaseXException($this->info ?? 'Unknown error');
         }
         return $result;
     }
@@ -74,7 +74,7 @@ class Session
      * @param string $xquery
      * @return Query
      */
-    public function query($xquery)
+    public function query(string $xquery): Query
     {
         return new Query($this, $xquery);
     }
@@ -85,7 +85,7 @@ class Session
      * @param string $name name of the new database
      * @param string $input XML to insert
      */
-    public function create($name, $input)
+    public function create(string $name, string $input): void
     {
         $this->sendCmd(8, $name, $input);
     }
@@ -96,7 +96,7 @@ class Session
      * @param string $path filesystem-like path
      * @param string $input XML to insert
      */
-    public function add($path, $input)
+    public function add(string $path, string $input): void
     {
         $this->sendCmd(9, $path, $input);
     }
@@ -107,12 +107,12 @@ class Session
      * @param string $path filesystem-like path
      * @param string $input XML to insert
      */
-    public function replace($path, $input)
+    public function replace(string $path, string $input): void
     {
         $this->sendCmd(12, $path, $input);
     }
 
-    public function store($path, $input)
+    public function store(string $path, string $input): void
     {
         $this->sendCmd(13, $path, $input);
     }
@@ -122,7 +122,7 @@ class Session
      *
      * @return string|null
      */
-    public function info()
+    public function info(): ?string
     {
         return $this->info;
     }
@@ -130,13 +130,13 @@ class Session
     /**
      * Close the connection.
      */
-    public function close()
+    public function close(): void
     {
         socket_write($this->socket, "exit".chr(0));
         socket_close($this->socket);
     }
 
-    private function init()
+    private function init(): void
     {
         $this->bpos = 0;
         $this->bsize = 0;
@@ -146,7 +146,7 @@ class Session
      * @internal
      * @return string
      */
-    public function readString()
+    public function readString(): string
     {
         $com = "";
         while (($d = $this->read()) != chr(0)) {
@@ -155,7 +155,7 @@ class Session
         return $com;
     }
 
-    private function read()
+    private function read(): string
     {
         if ($this->bpos == $this->bsize) {
             $this->bsize = socket_recv($this->socket, $this->buffer, 4096, 0);
@@ -164,16 +164,16 @@ class Session
         return $this->buffer[$this->bpos++];
     }
 
-    private function sendCmd($code, $arg, $input)
+    private function sendCmd(int $code, string $arg, string $input): void
     {
         socket_write($this->socket, chr($code).$arg.chr(0).$input.chr(0));
         $this->info = $this->receive();
         if ($this->ok() != true) {
-            throw new BaseXException($this->info);
+            throw new BaseXException($this->info ?? 'Unknown error');
         }
     }
 
-    public function send($str)
+    public function send(string $str): void
     {
         socket_write($this->socket, $str.chr(0));
     }
@@ -184,7 +184,7 @@ class Session
      * @internal not idempotent, not intended for use by client code
      * @return bool
      */
-    public function ok()
+    public function ok(): bool
     {
         return $this->read() == chr(0);
     }
@@ -193,7 +193,7 @@ class Session
      * @internal
      * @return string
      */
-    public function receive()
+    public function receive(): string
     {
         $this->init();
         return $this->readString();

--- a/src/Session.php
+++ b/src/Session.php
@@ -159,6 +159,9 @@ class Session
     {
         if ($this->bpos == $this->bsize) {
             $this->bsize = socket_recv($this->socket, $this->buffer, 4096, 0);
+            if ($this->bsize === false) {
+                throw new BaseXException("Socket read error: " . socket_last_error($this->socket));
+            }
             $this->bpos = 0;
         }
         return $this->buffer[$this->bpos++];


### PR DESCRIPTION
Hi @jschroed91 

would you please consider this PR to bring fixes for PHP 8+ to avoid deprecation notices like:
```
Return type of Caxy\BaseX\Query::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used...
```

72785b6 is the minimal required fix, and as I was on it I also added type hints for other methods in b4b2b8f324cf672a8680b854cb9fb7a63122baee.

Thanks

Edit: Also added the fix proposed by the review
<img width="771" height="559" alt="image" src="https://github.com/user-attachments/assets/44429d91-d1fd-4b6d-a18d-b5c26c7185e9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved overall stability and reliability via comprehensive type safety and stronger input/output contracts.
  * More consistent query/session behavior, safer streaming/iteration, and clearer error reporting for connection and command failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->